### PR TITLE
Bump Istio version from 1.26.2 to 1.27.1

### DIFF
--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -72,7 +72,7 @@ variable "gateway_memory_requests" {
 variable "istio_version" {
   description = "The version to install, this is used for the chart as well as the image tag"
   type        = string
-  default     = "1.26.2"
+  default     = "1.27.1"
 }
 
 variable "labels" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Istio version to 1.27.1 for new deployments.
  * Ensures new environments provision with the latest stable control plane and data plane defaults.
  * Users creating or reprovisioning environments will receive the newer version automatically; existing environments are unaffected unless re-applied.
  * Recommend validating add-on and gateway compatibility with 1.27.1 before rollout and reviewing any upstream changes that may affect traffic management or telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->